### PR TITLE
Use PSP created by kiam. 

### DIFF
--- a/templates/kiam.yaml
+++ b/templates/kiam.yaml
@@ -1,4 +1,7 @@
 extraArgs: {}
+psp:
+  # Specifies whether PodSecurityPolicies should be created
+  create: true
 
 agent:
   image:


### PR DESCRIPTION
This will create PSP which kiam use to run as privileged containers.
And hence isolate kiam to use NET_RAW capability which will be removed from psp:privileged.

Related to: https://github.com/ministryofjustice/cloud-platform/issues/2335